### PR TITLE
Updated get_client_addr

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5407,7 +5407,7 @@ function get_client_addr($client_addr = false) {
 					} else {
 						$client_addr = $header_ip;
 						cacti_log('DEBUG: Using remote client IP Address found in header (' . $header . '): ' . $client_addr . ' (' . $_SERVER[$header] . ')', false, 'AUTH', POLLER_VERBOSITY_DEBUG);
-						break;
+						break 2;
 					}
 				}
 			}


### PR DESCRIPTION
I updated this function so that it works as intended and breaks out of the second loop too! Otherwise client headers won't be detected and always use REMOTE_ADDR.